### PR TITLE
[WORKFLOWS-398] Generate Nextflow configuration with optimized CPU and memory allocations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,7 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Example data and output
+*.json
+*.config

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,14 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+typer = "*"
+
+[dev-packages]
+black = "*"
+mypy = "*"
+
+[requires]
+python_version = "3.10"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,149 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "bbfe7250cd9d13c2daafba87a7c79d369a30e9c9d3e6f2f26115f0e44d0274a7"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.10"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "click": {
+            "hashes": [
+                "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e",
+                "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==8.1.3"
+        },
+        "typer": {
+            "hashes": [
+                "sha256:b5e704f4e48ec263de1c0b3a2387cd405a13767d2f907f44c1a08cbad96f606d",
+                "sha256:ff797846578a9f2a201b53442aedeb543319466870fbe1c701eab66dd7681165"
+            ],
+            "index": "pypi",
+            "version": "==0.7.0"
+        }
+    },
+    "develop": {
+        "black": {
+            "hashes": [
+                "sha256:064101748afa12ad2291c2b91c960be28b817c0c7eaa35bec09cc63aa56493c5",
+                "sha256:0945e13506be58bf7db93ee5853243eb368ace1c08a24c65ce108986eac65915",
+                "sha256:11c410f71b876f961d1de77b9699ad19f939094c3a677323f43d7a29855fe326",
+                "sha256:1c7b8d606e728a41ea1ccbd7264677e494e87cf630e399262ced92d4a8dac940",
+                "sha256:1d06691f1eb8de91cd1b322f21e3bfc9efe0c7ca1f0e1eb1db44ea367dff656b",
+                "sha256:3238f2aacf827d18d26db07524e44741233ae09a584273aa059066d644ca7b30",
+                "sha256:32daa9783106c28815d05b724238e30718f34155653d4d6e125dc7daec8e260c",
+                "sha256:35d1381d7a22cc5b2be2f72c7dfdae4072a3336060635718cc7e1ede24221d6c",
+                "sha256:3a150542a204124ed00683f0db1f5cf1c2aaaa9cc3495b7a3b5976fb136090ab",
+                "sha256:48f9d345675bb7fbc3dd85821b12487e1b9a75242028adad0333ce36ed2a6d27",
+                "sha256:50cb33cac881766a5cd9913e10ff75b1e8eb71babf4c7104f2e9c52da1fb7de2",
+                "sha256:562bd3a70495facf56814293149e51aa1be9931567474993c7942ff7d3533961",
+                "sha256:67de8d0c209eb5b330cce2469503de11bca4085880d62f1628bd9972cc3366b9",
+                "sha256:6b39abdfb402002b8a7d030ccc85cf5afff64ee90fa4c5aebc531e3ad0175ddb",
+                "sha256:6f3c333ea1dd6771b2d3777482429864f8e258899f6ff05826c3a4fcc5ce3f70",
+                "sha256:714290490c18fb0126baa0fca0a54ee795f7502b44177e1ce7624ba1c00f2331",
+                "sha256:7c3eb7cea23904399866c55826b31c1f55bbcd3890ce22ff70466b907b6775c2",
+                "sha256:92c543f6854c28a3c7f39f4d9b7694f9a6eb9d3c5e2ece488c327b6e7ea9b266",
+                "sha256:a6f6886c9869d4daae2d1715ce34a19bbc4b95006d20ed785ca00fa03cba312d",
+                "sha256:a8a968125d0a6a404842fa1bf0b349a568634f856aa08ffaff40ae0dfa52e7c6",
+                "sha256:c7ab5790333c448903c4b721b59c0d80b11fe5e9803d8703e84dcb8da56fec1b",
+                "sha256:e114420bf26b90d4b9daa597351337762b63039752bdf72bf361364c1aa05925",
+                "sha256:e198cf27888ad6f4ff331ca1c48ffc038848ea9f031a3b40ba36aced7e22f2c8",
+                "sha256:ec751418022185b0c1bb7d7736e6933d40bbb14c14a0abcf9123d1b159f98dd4",
+                "sha256:f0bd2f4a58d6666500542b26354978218a9babcdc972722f4bf90779524515f3"
+            ],
+            "index": "pypi",
+            "version": "==23.3.0"
+        },
+        "click": {
+            "hashes": [
+                "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e",
+                "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==8.1.3"
+        },
+        "mypy": {
+            "hashes": [
+                "sha256:023fe9e618182ca6317ae89833ba422c411469156b690fde6a315ad10695a521",
+                "sha256:031fc69c9a7e12bcc5660b74122ed84b3f1c505e762cc4296884096c6d8ee140",
+                "sha256:2de7babe398cb7a85ac7f1fd5c42f396c215ab3eff731b4d761d68d0f6a80f48",
+                "sha256:2e93a8a553e0394b26c4ca683923b85a69f7ccdc0139e6acd1354cc884fe0128",
+                "sha256:390bc685ec209ada4e9d35068ac6988c60160b2b703072d2850457b62499e336",
+                "sha256:3a2d219775a120581a0ae8ca392b31f238d452729adbcb6892fa89688cb8306a",
+                "sha256:3efde4af6f2d3ccf58ae825495dbb8d74abd6d176ee686ce2ab19bd025273f41",
+                "sha256:4a99fe1768925e4a139aace8f3fb66db3576ee1c30b9c0f70f744ead7e329c9f",
+                "sha256:4b41412df69ec06ab141808d12e0bf2823717b1c363bd77b4c0820feaa37249e",
+                "sha256:4c8d8c6b80aa4a1689f2a179d31d86ae1367ea4a12855cc13aa3ba24bb36b2d8",
+                "sha256:4d19f1a239d59f10fdc31263d48b7937c585810288376671eaf75380b074f238",
+                "sha256:4e4a682b3f2489d218751981639cffc4e281d548f9d517addfd5a2917ac78119",
+                "sha256:695c45cea7e8abb6f088a34a6034b1d273122e5530aeebb9c09626cea6dca4cb",
+                "sha256:701189408b460a2ff42b984e6bd45c3f41f0ac9f5f58b8873bbedc511900086d",
+                "sha256:70894c5345bea98321a2fe84df35f43ee7bb0feec117a71420c60459fc3e1eed",
+                "sha256:8293a216e902ac12779eb7a08f2bc39ec6c878d7c6025aa59464e0c4c16f7eb9",
+                "sha256:8d26b513225ffd3eacece727f4387bdce6469192ef029ca9dd469940158bc89e",
+                "sha256:a197ad3a774f8e74f21e428f0de7f60ad26a8d23437b69638aac2764d1e06a6a",
+                "sha256:bea55fc25b96c53affab852ad94bf111a3083bc1d8b0c76a61dd101d8a388cf5",
+                "sha256:c9a084bce1061e55cdc0493a2ad890375af359c766b8ac311ac8120d3a472950",
+                "sha256:d0e9464a0af6715852267bf29c9553e4555b61f5904a4fc538547a4d67617937",
+                "sha256:d8e9187bfcd5ffedbe87403195e1fc340189a68463903c39e2b63307c9fa0394",
+                "sha256:eaeaa0888b7f3ccb7bcd40b50497ca30923dba14f385bde4af78fac713d6d6f6",
+                "sha256:f46af8d162f3d470d8ffc997aaf7a269996d205f9d746124a179d3abe05ac602",
+                "sha256:f70a40410d774ae23fcb4afbbeca652905a04de7948eaf0b1789c8d1426b72d1",
+                "sha256:fe91be1c51c90e2afe6827601ca14353bbf3953f343c2129fa1e247d55fd95ba"
+            ],
+            "index": "pypi",
+            "version": "==1.2.0"
+        },
+        "mypy-extensions": {
+            "hashes": [
+                "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d",
+                "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==1.0.0"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:994793af429502c4ea2ebf6bf664629d07c1a9fe974af92966e4b8d2df7edc61",
+                "sha256:a392980d2b6cffa644431898be54b0045151319d1e7ec34f0cfed48767dd334f"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==23.1"
+        },
+        "pathspec": {
+            "hashes": [
+                "sha256:2798de800fa92780e33acca925945e9a19a133b715067cf165b8866c15a31687",
+                "sha256:d8af70af76652554bd134c22b3e8a1cc46ed7d91edcdd721ef1a0c51a84a5293"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==0.11.1"
+        },
+        "platformdirs": {
+            "hashes": [
+                "sha256:01437886022decaf285d8972f9526397bfae2ac55480ed372ed6d9eca048870a",
+                "sha256:a5e1536e5ea4b1c238a1364da17ff2993d5bd28e15600c2c8224008aff6bbcad"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==3.4.0"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb",
+                "sha256:fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==4.5.0"
+        }
+    }
+}

--- a/optimize-nextflow.py
+++ b/optimize-nextflow.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+
+import json
+import shutil
+from collections import namedtuple
+from dataclasses import astuple, dataclass
+from functools import cached_property
+from math import ceil
+from pathlib import Path
+from textwrap import dedent, indent
+from typing import Generic, TypeVar
+
+import typer
+
+Number = TypeVar("Number", int, float)
+
+app = typer.Typer(
+    context_settings={"max_content_width": shutil.get_terminal_size().columns}
+)
+
+
+@app.command()
+def from_json(metrics_path: Path):
+    """Process the metrics JSON output from the Tower CLI.
+
+    Here's an example Tower CLI command:
+
+        tw --output "json" runs view -w "<org>/<workspace>" -i "<workflow-id>" metrics
+    """
+    json_parser = MetricsJsonParser(metrics_path)
+    task_metrics = json_parser.parse()
+    config_generator = NextflowConfigGenerator(task_metrics)
+    config = config_generator.generate()
+    print(config)
+
+
+@app.command()
+def from_api():
+    """Process the metrics JSON output from the Tower API.
+
+    Not implemented yet.
+    """
+    ...
+
+
+@dataclass
+class Stats(Generic[Number]):
+    q1: Number
+    q2: Number
+    q3: Number
+    min: Number
+    max: Number
+    mean: Number
+
+    @cached_property
+    def max_q3_ratio(self):
+        return round(self.max / self.q3, 2)
+
+
+@dataclass
+class TaskMetrics:
+    name: str
+    mem: Stats
+    mem_pct: Stats
+    cpu: Stats
+    cpu_pct: Stats
+
+    @staticmethod
+    def bytes_to_gb(memory: int) -> int:
+        memory_gb = memory / 1024**3
+        return ceil(memory_gb + 0.5)
+
+    @staticmethod
+    def load_to_cores(load: float) -> int:
+        cores = load / 100
+        return ceil(cores + 0.5)
+
+    @cached_property
+    def mem_gb(self) -> Stats:
+        values = astuple(self.mem)
+        values_adj = [self.bytes_to_gb(x) for x in values]
+        return Stats(*values_adj)
+
+    @cached_property
+    def cpu_cores(self) -> Stats:
+        values = astuple(self.cpu)
+        values_adj = [self.load_to_cores(x) for x in values]
+        return Stats(*values_adj)
+
+    def optimize_mem(self) -> int:
+        if self.mem.max == 1 and self.mem_pct.max <= 80:
+            return self.mem_gb.max
+        elif self.mem_gb.max <= 8:
+            return self.mem_gb.max
+        elif self.mem_gb.max_q3_ratio <= 1.5 and self.mem_gb.max <= 32:
+            return self.mem_gb.max
+        elif self.mem_gb.max_q3_ratio <= 1.2 and self.mem_gb.max <= 64:
+            return self.mem_gb.max
+        else:
+            return self.mem_gb.q3
+
+    def optimize_cpu(self) -> int:
+        if self.cpu_cores.max_q3_ratio <= 2 and self.cpu_cores.max <= 8:
+            return self.cpu_cores.max
+        elif self.cpu_cores.max_q3_ratio <= 1.5 and self.cpu_cores.max <= 16:
+            return self.cpu_cores.max
+        else:
+            return self.cpu_cores.q3
+
+
+@dataclass
+class MetricsJsonParser:
+    json_path: Path
+
+    RawPctPair = namedtuple("RawPctPair", ["raw", "pct"])
+
+    @cached_property
+    def json(self):
+        return json.load(self.json_path.open())
+
+    def parse(self) -> list[TaskMetrics]:
+        mem_metrics = self.parse_resource("metricsMemory", "memRaw", "memUsage")
+        cpu_metrics = self.parse_resource("metricsCpu", "cpuRaw", "cpuUsage")
+        tasks = set(mem_metrics) & set(cpu_metrics)
+
+        all_task_metrics = list()
+        for task in tasks:
+            mem = mem_metrics[task]
+            cpu = cpu_metrics[task]
+            task_metrics = TaskMetrics(task, mem.raw, mem.pct, cpu.raw, cpu.pct)
+            all_task_metrics.append(task_metrics)
+        return all_task_metrics
+
+    def parse_resource(self, top_key, raw_key, pct_key) -> dict[str, RawPctPair]:
+        metrics = dict()
+        for task in self.json[top_key]:
+            task_name, task_metrics = task.popitem()
+            if not task_metrics:
+                continue
+            usage_raw = Stats(**task_metrics[raw_key])
+            usage_pct = Stats(**task_metrics[pct_key])
+            metrics[task_name] = self.RawPctPair(usage_raw, usage_pct)
+        return metrics
+
+
+@dataclass
+class NextflowConfigGenerator:
+    task_metrics: list[TaskMetrics]
+
+    def generate(self) -> str:
+        prefix = "process { \n"
+        suffix = "\n }"
+
+        task_configs = list()
+        for task in self.task_metrics:
+            task_config = self.generate_single(task)
+            task_config_fmt = indent(task_config, "  ")
+            task_configs.append(task_config_fmt)
+        task_configs_concat = "".join(task_configs)
+
+        return prefix + task_configs_concat + suffix
+
+    @staticmethod
+    def generate_single(task_metrics: TaskMetrics) -> str:
+        mem_optimal = task_metrics.optimize_mem()
+        cpu_optimal = task_metrics.optimize_cpu()
+        config = f"""
+            withName: { task_metrics.name } {{
+                memory = { mem_optimal }.GB
+                cpu = { cpu_optimal }
+            }}
+        """
+        return dedent(config)
+
+
+if __name__ == "__main__":
+    app()

--- a/optimize-nextflow.py
+++ b/optimize-nextflow.py
@@ -28,8 +28,8 @@ def from_json(metrics_path: Path):
         tw --output "json" runs view -w "<org>/<workspace>" -i "<workflow-id>" metrics
     """
     json_parser = MetricsJsonParser(metrics_path)
-    task_metrics = json_parser.parse()
-    config_generator = NextflowConfigGenerator(task_metrics)
+    process_metrics = json_parser.parse()
+    config_generator = NextflowConfigGenerator(process_metrics)
     config = config_generator.generate()
     print(config)
 
@@ -40,11 +40,13 @@ def from_api():
 
     Not implemented yet.
     """
-    ...
+    raise NotImplementedError()
 
 
 @dataclass
 class Stats(Generic[Number]):
+    """Suite of statistics."""
+
     q1: Number
     q2: Number
     q3: Number
@@ -54,11 +56,14 @@ class Stats(Generic[Number]):
 
     @cached_property
     def max_q3_ratio(self):
+        """Ratio between the max and Q3 values."""
         return round(self.max / self.q3, 2)
 
 
 @dataclass
-class TaskMetrics:
+class ProcessMetrics:
+    """Set of metrics for a process."""
+
     name: str
     mem: Stats
     mem_pct: Stats
@@ -67,27 +72,58 @@ class TaskMetrics:
 
     @staticmethod
     def bytes_to_gb(memory: int) -> int:
+        """Convert memory in bytes to GB (with some buffer).
+
+        Args:
+            memory: Memory in bytes.
+
+        Returns:
+            Memory in GB (with some buffer).
+        """
         memory_gb = memory / 1024**3
         return ceil(memory_gb + 0.5)
 
     @staticmethod
     def load_to_cores(load: float) -> int:
+        """Convert CPU load to number of cores (with some buffer).
+
+        Args:
+            load: CPU load in percentage.
+
+        Returns:
+            Number of CPU cores (with some buffer).
+        """
         cores = load / 100
         return ceil(cores + 0.5)
 
     @cached_property
     def mem_gb(self) -> Stats:
+        """Retrieve memory statistics in GB.
+
+        Returns:
+            Memory statistics in GB.
+        """
         values = astuple(self.mem)
         values_adj = [self.bytes_to_gb(x) for x in values]
         return Stats(*values_adj)
 
     @cached_property
     def cpu_cores(self) -> Stats:
+        """Retrieve CPU statistics in cores.
+
+        Returns:
+            CPU statistics in cores.
+        """
         values = astuple(self.cpu)
         values_adj = [self.load_to_cores(x) for x in values]
         return Stats(*values_adj)
 
     def optimize_mem(self) -> int:
+        """Optimize memory allocation based on heuristics.
+
+        Returns:
+            Optimized memory allocation.
+        """
         if self.mem.max == 1 and self.mem_pct.max <= 80:
             return self.mem_gb.max
         elif self.mem_gb.max <= 8:
@@ -100,6 +136,11 @@ class TaskMetrics:
             return self.mem_gb.q3
 
     def optimize_cpu(self) -> int:
+        """Optimize CPU allocation based on heuristics.
+
+        Returns:
+            Optimized CPU allocation.
+        """
         if self.cpu_cores.max_q3_ratio <= 2 and self.cpu_cores.max <= 8:
             return self.cpu_cores.max
         elif self.cpu_cores.max_q3_ratio <= 1.5 and self.cpu_cores.max <= 16:
@@ -110,62 +151,97 @@ class TaskMetrics:
 
 @dataclass
 class MetricsJsonParser:
+    """Parser for JSON file with Tower process metrics."""
+
     json_path: Path
 
     RawPctPair = namedtuple("RawPctPair", ["raw", "pct"])
 
     @cached_property
     def json(self):
+        """De-serialized JSON contents."""
         return json.load(self.json_path.open())
 
-    def parse(self) -> list[TaskMetrics]:
+    def parse(self) -> list[ProcessMetrics]:
+        """Parse JSON file with Tower process metrics.
+
+        Returns:
+            List of Tower process metrics.
+        """
         mem_metrics = self.parse_resource("metricsMemory", "memRaw", "memUsage")
         cpu_metrics = self.parse_resource("metricsCpu", "cpuRaw", "cpuUsage")
-        tasks = set(mem_metrics) & set(cpu_metrics)
+        processes = set(mem_metrics) & set(cpu_metrics)
 
-        all_task_metrics = list()
-        for task in tasks:
-            mem = mem_metrics[task]
-            cpu = cpu_metrics[task]
-            task_metrics = TaskMetrics(task, mem.raw, mem.pct, cpu.raw, cpu.pct)
-            all_task_metrics.append(task_metrics)
-        return all_task_metrics
+        all_process_metrics = list()
+        for process in processes:
+            mem = mem_metrics[process]
+            cpu = cpu_metrics[process]
+            process_metrics = ProcessMetrics(
+                process, mem.raw, mem.pct, cpu.raw, cpu.pct
+            )
+            all_process_metrics.append(process_metrics)
+        return all_process_metrics
 
     def parse_resource(self, top_key, raw_key, pct_key) -> dict[str, RawPctPair]:
+        """Parse the statistics for a specific resource.
+
+        Args:
+            top_key: Resource-specific top-level key.
+            raw_key: Key for raw resource usage.
+            pct_key: Key for percent resource usage.
+
+        Returns:
+            Resource usage statistics for each process.
+        """
         metrics = dict()
-        for task in self.json[top_key]:
-            task_name, task_metrics = task.popitem()
-            if not task_metrics:
+        for process in self.json[top_key]:
+            process_name, process_metrics = process.popitem()
+            if not process_metrics:
                 continue
-            usage_raw = Stats(**task_metrics[raw_key])
-            usage_pct = Stats(**task_metrics[pct_key])
-            metrics[task_name] = self.RawPctPair(usage_raw, usage_pct)
+            usage_raw = Stats(**process_metrics[raw_key])
+            usage_pct = Stats(**process_metrics[pct_key])
+            metrics[process_name] = self.RawPctPair(usage_raw, usage_pct)
         return metrics
 
 
 @dataclass
 class NextflowConfigGenerator:
-    task_metrics: list[TaskMetrics]
+    """Generator for Nextflow configuration."""
+
+    process_metrics: list[ProcessMetrics]
 
     def generate(self) -> str:
+        """Generate Nextflow configuration based on process metrics.
+
+        Returns:
+            Serialized Nextflow configuration.
+        """
         prefix = "process { \n"
         suffix = "\n }"
 
-        task_configs = list()
-        for task in self.task_metrics:
-            task_config = self.generate_single(task)
-            task_config_fmt = indent(task_config, "  ")
-            task_configs.append(task_config_fmt)
-        task_configs_concat = "".join(task_configs)
+        process_configs = list()
+        for process in self.process_metrics:
+            process_config = self.generate_single(process)
+            process_config_fmt = indent(process_config, "  ")
+            process_configs.append(process_config_fmt)
+        process_configs_concat = "".join(process_configs)
 
-        return prefix + task_configs_concat + suffix
+        return prefix + process_configs_concat + suffix
 
     @staticmethod
-    def generate_single(task_metrics: TaskMetrics) -> str:
-        mem_optimal = task_metrics.optimize_mem()
-        cpu_optimal = task_metrics.optimize_cpu()
+    def generate_single(process_metrics: ProcessMetrics) -> str:
+        """Generate Nextflow configuration for a single process.
+
+        Args:
+            process_metrics: Resource metrics for a single process.
+
+        Returns:
+            Serialized Nextflow configuration snippet.
+        """
+        mem_optimal = process_metrics.optimize_mem()
+        cpu_optimal = process_metrics.optimize_cpu()
         config = f"""
-            withName: { task_metrics.name } {{
+            withName: { process_metrics.name } {{
                 memory = { mem_optimal }.GB
                 cpu = { cpu_optimal }
             }}


### PR DESCRIPTION
I wrote a Python script for optimizing resource allocations for Nextflow workflows. It takes the metrics from a previous workflow run and produces a Nextflow configuration with optimized memory and CPU request for each task. Currently, I implemented it to process the JSON output from the Tower CLI (see example command below). A future version could pull the metrics directly from the API. This will be easier once we merge the support for the Tower API in py-orca.

```console
❯ tw --output "json" runs view -w "Sage-Bionetworks/ntap-add5-project" -i "594SulltdOH43M" metrics > metrics-rnaseq.json
❯ python optimize-nextflow.py from-json metrics-rnaseq.json > nextflow.config
```

You can inspect the `metrics-rnaseq.json` file in this [Jira comment](https://sagebionetworks.jira.com/browse/WORKFLOWS-398?focusedCommentId=171467). 

<details><summary>Command Output</summary>
<p>

```nextflow
process { 

  withName: UCSC_BEDCLIP {
      memory = 1.GB
      cpu = 2
  }

  withName: SAMTOOLS_IDXSTATS {
      memory = 1.GB
      cpu = 2
  }

  withName: SALMON_TXIMPORT {
      memory = 3.GB
      cpu = 2
  }

  withName: FASTQC {
      memory = 2.GB
      cpu = 3
  }

  withName: RSEQC_JUNCTIONANNOTATION {
      memory = 1.GB
      cpu = 2
  }

  withName: SAMTOOLS_INDEX {
      memory = 1.GB
      cpu = 3
  }

  withName: MULTIQC_CUSTOM_BIOTYPE {
      memory = 1.GB
      cpu = 2
  }

  withName: PICARD_MARKDUPLICATES {
      memory = 34.GB
      cpu = 2
  }

  withName: SALMON_QUANT {
      memory = 12.GB
      cpu = 6
  }

  withName: SAMPLESHEET_CHECK {
      memory = 1.GB
      cpu = 2
  }

  withName: CUSTOM_DUMPSOFTWAREVERSIONS {
      memory = 1.GB
      cpu = 2
  }

  withName: CAT_FASTQ {
      memory = 1.GB
      cpu = 2
  }

  withName: RSEQC_INFEREXPERIMENT {
      memory = 1.GB
      cpu = 1
  }

  withName: STRINGTIE_STRINGTIE {
      memory = 2.GB
      cpu = 5
  }

  withName: RSEQC_INNERDISTANCE {
      memory = 2.GB
      cpu = 2
  }

  withName: DUPRADAR {
      memory = 2.GB
      cpu = 2
  }

  withName: SAMTOOLS_FLAGSTAT {
      memory = 1.GB
      cpu = 3
  }

  withName: TRIMGALORE {
      memory = 4.GB
      cpu = 5
  }

  withName: MULTIQC {
      memory = 2.GB
      cpu = 2
  }

  withName: RSEQC_READDUPLICATION {
      memory = 16.GB
      cpu = 2
  }

  withName: DESEQ2_QC_STAR_SALMON {
      memory = 3.GB
      cpu = 20
  }

  withName: RSEQC_JUNCTIONSATURATION {
      memory = 4.GB
      cpu = 2
  }

  withName: PRESEQ_LCEXTRAP {
      memory = 5.GB
      cpu = 2
  }

  withName: SALMON_SE_GENE_SCALED {
      memory = 2.GB
      cpu = 2
  }

  withName: SAMTOOLS_SORT {
      memory = 6.GB
      cpu = 5
  }

  withName: UCSC_BEDGRAPHTOBIGWIG {
      memory = 1.GB
      cpu = 2
  }

  withName: SUBREAD_FEATURECOUNTS {
      memory = 3.GB
      cpu = 5
  }

  withName: QUALIMAP_RNASEQ {
      memory = 29.GB
      cpu = 2
  }

  withName: SAMTOOLS_STATS {
      memory = 1.GB
      cpu = 3
  }

  withName: SALMON_SE_GENE_LENGTH_SCALED {
      memory = 2.GB
      cpu = 2
  }

  withName: STAR_ALIGN {
      memory = 37.GB
      cpu = 12
  }

  withName: SALMON_TX2GENE {
      memory = 11.GB
      cpu = 2
  }

  withName: CUSTOM_GETCHROMSIZES {
      memory = 1.GB
      cpu = 1
  }

  withName: BEDTOOLS_GENOMECOV {
      memory = 12.GB
      cpu = 2
  }

  withName: SALMON_SE_TRANSCRIPT {
      memory = 2.GB
      cpu = 2
  }

  withName: RSEQC_READDISTRIBUTION {
      memory = 2.GB
      cpu = 2
  }

  withName: SALMON_SE_GENE {
      memory = 2.GB
      cpu = 2
  }

  withName: RSEQC_BAMSTAT {
      memory = 1.GB
      cpu = 2
  }

 }

```

</p>
</details> 