### PR TITLE
[WORKFLOWS-389] Increase memory on later attempts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,4 @@ cython_debug/
 # Example data and output
 *.json
 *.config
+.nextflow*

--- a/optimize-nextflow.py
+++ b/optimize-nextflow.py
@@ -12,7 +12,7 @@ from typing import Generic, TypeVar
 
 import typer
 
-MAX_RETRIES = 5
+MAX_RETRIES = 2
 
 Number = TypeVar("Number", int, float)
 

--- a/optimize-nextflow.py
+++ b/optimize-nextflow.py
@@ -228,6 +228,7 @@ class NextflowConfigGenerator:
         process_configs_concat = "".join(process_configs)
         process_configs_concat = indent(process_configs_concat, " " * 8)
 
+        # TODO: Switch to Jinja templating
         full_config = f"""\
         process {{
         {process_configs_concat}


### PR DESCRIPTION
As part of my work on WORKFLOWS-530, I realized that the memory allocations generated by `optimize-nextflow` should increase on later attempts instead of being static. This PR implements this feature. 